### PR TITLE
Add ordering parameter to GET /v0/orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Retrieves a list of orders given query parameters. Default is all open orders.
 
 #### Parameters
 
-* tokenAscByPrice [string]: token by which to sort the orders in ascending order of the price of that token. By default the response returned by this endpoint is unsorted.
+* ascByBaseToken [string]: token designated as the baseToken in the [currency pair calculation](https://en.wikipedia.org/wiki/Currency_pair) of price by which the orders will be sorted in ascending order. Within the price sorted orders, the orders are further sorted first by fees, then by expiration in ascending order. By default the response returned by this endpoint is unsorted. Further explanation available [here](https://github.com/0xProject/standard-relayer-api/pull/3#issuecomment-327383439).
 * exchangeContractAddress [string]: returns orders created for this exchange address
 * isExpired [boolean]: returns expired orders (defaults to false)
 * isOpen [boolean]: returns open orders (defaults to true)
@@ -90,8 +90,6 @@ Retrieves a list of orders given query parameters. Default is all open orders.
 * trader [string]: returns orders where maker or taker is trader address
 * feeRecipient [string]: returns orders where feeRecipient is feeRecipient address
 * limit [number]: number of orders to return
-
-**Note:** The price of tokenA is the amount of tokenB required to purchase 1 tokenA.
 
 #### Response
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Retrieves a list of orders given query parameters. Default is all open orders.
 
 #### Parameters
 
+* tokenAscByPrice [string]: token by which to sort the orders in ascending order of the price of that token. By default the response returned by this endpoint is unsorted.
 * exchangeContractAddress [string]: returns orders created for this exchange address
 * isExpired [boolean]: returns expired orders (defaults to false)
 * isOpen [boolean]: returns open orders (defaults to true)
@@ -83,6 +84,8 @@ Retrieves a list of orders given query parameters. Default is all open orders.
 * trader [string]: returns orders where maker or taker is trader address
 * feeRecipient [string]: returns orders where feeRecipient is feeRecipient address
 * limit [number]: number of orders to return
+
+**Note:** The price of tokenA is the amount of tokenB required to purchase 1 tokenA.
 
 #### Response
 


### PR DESCRIPTION
Currently the results from `/v0/orders` are returned unordered. Given a sufficient number of orders in a relayers orderbook, it will become expensive for clients to request all orders for a given query. In addition, most clients will not be equally interested in all orders. 

Some client examples:
- A dApp wants to fetch the cheapest order for it's user to acquire `WETH` for `MLN`. In this case, the dApp would like to request all orders where `makerToken` is `WETH`, `takerToken` is `MLN`. It would further want the orders returned in ascending order of the price of `WETH` in terms on `MLN` by setting `tokenAscByPrice` to `WETH`. The dApp can then simply take the first few orders that have sufficient liquidity for the desired trade, and it is guaranteed the best price.

- A trading bot wants to query the depth of a particular orderbook in order to inform it's trading decisions. The bot therefore fetches all trades with parameters `tokenA` equal `MLN` and `tokenB` equal `WETH`, thus fetching all orders involving this trading pair. In order to define which orders are bids and which asks, as well as return the orders ordered by price, it can set `tokenAscByPrice` to the desired `baseToken` (as opposed to `quoteToken`). Given that this is an efficient market, this query will return the orders from the lowest bid to the highest ask. In order to find the "market price" the bot would simply need to scan the orders to find where the bids meet the asks.

Some way of ordering the orders returned to clients will be necessary for them to build performant applications. Since a main purpose of the Standard Relayer API is sharing liquidity, we should design it such that it is easy for clients to fetch the most competitive orders for a given token pair.

My proposed solution involves letting them elect a `baseToken` and have the orders returned sorted by the price of this `baseToken` in terms of a `quoteToken`. The orders are always returned in ascending order because if one wanted the reverse, one can simply flip the `baseToken` for the `quoteToken`. 

I'm open to suggestions and alternative solutions but thought it would make sense to start the discussion about the ordering of orders with a proposal.