### PR TITLE
Update token_pairs, signed_order, and fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ const validatorResult: ValidatorResult = validator.validate(tokenPairsResponse, 
 
 - All token amounts are sent in amounts of the smallest level of precision (base units). (e.g if a token has 18 decimal places, selling 1 token would show up as selling `'1000000000000000000'` units by this API).
 - All addresses are sent as lower-case (non-checksummed) Ethereum addresses with the `0x` prefix.
-- `CLOSED` state means the order has been entirely filled/canceled.
 
 ## Endpoints
 
 ### GET /v0/token_pairs
 
 Retrieves a list of available token pairs and the information required to trade them.
+
+#### Parameters
+
+* tokenA=&tokenB [string]: returns token pairs that contain tokenA and tokenB (in any order). Setting only tokenA or tokenB returns pairs filtered by that token only
 
 #### Response
 
@@ -47,28 +50,25 @@ Retrieves a list of available token pairs and the information required to trade 
     {
         "tokenA": {
             "address": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
-            "symbol": "MKR",
-            "decimals": 18,
             "minAmount": "0",
             "maxAmount": "10000000000000000000",
             "precision": 5
         },
         "tokenB": {
             "address": "0xef7fff64389b814a946f3e92105513705ca6b990",
-            "symbol": "GLM",
-            "decimals": 18,
             "minAmount": "0",
             "maxAmount": "50000000000000000000",
             "precision": 5
         }
-    }
+    },
     ...
 ]
 ```
 
-- `precision` - the desired price precision a Relayer would like to support within their orderbook
-- `minAmount` - the minimum trade amount the Relayer will accept
-- `maxAmount` - the maximum trade amount the Relayer will accept
+- `address` - address of the token
+- `minAmount` - the minimum trade amount the relayer will accept
+- `maxAmount` - the maximum trade amount the relayer will accept
+- `precision` - the desired price precision a relayer would like to support within their orderbook
 
 ### GET /v0/orders
 
@@ -76,7 +76,7 @@ Retrieves a list of orders given query parameters. Default is all open orders.
 
 #### Parameters
 
-* ascByBaseToken [string]: token designated as the baseToken in the [currency pair calculation](https://en.wikipedia.org/wiki/Currency_pair) of price by which the orders will be sorted in ascending order. Within the price sorted orders, the orders are further sorted first by fees, then by expiration in ascending order. By default the response returned by this endpoint is unsorted. Further explanation available [here](https://github.com/0xProject/standard-relayer-api/pull/3#issuecomment-327383439).
+* ascByBaseToken [string]: token designated as the baseToken in the [currency pair calculation](https://en.wikipedia.org/wiki/Currency_pair) of price by which the orders will be sorted in ascending order. Within the price sorted orders, the orders are further sorted first by total fees, then by expiration in ascending order. By default the response returned by this endpoint is unsorted. Further explanation available [here](https://github.com/0xProject/standard-relayer-api/pull/3#issuecomment-327383439).
 * exchangeContractAddress [string]: returns orders created for this exchange address
 * isExpired [boolean]: returns expired orders (defaults to false)
 * isOpen [boolean]: returns open orders (defaults to true)
@@ -93,79 +93,66 @@ Retrieves a list of orders given query parameters. Default is all open orders.
 
 #### Response
 
-[See response schema](https://github.com/0xProject/json-schemas/blob/master/schemas/relayer_api_order_response_schema.ts#L1)
+[See response schema](https://github.com/0xProject/json-schemas/blob/master/schemas/relayer_api_orders_response_schema.ts#L1)
 
 ```
 [
     {
         "signedOrder": {
+            "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
             "maker": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
             "taker": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
-            "makerFee": "100000000000000",
-            "takerFee": "200000000000000",
-            "makerTokenAmount": "10000000000000000",
-            "takerTokenAmount": "20000000000000000",
             "makerTokenAddress": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
             "takerTokenAddress": "0xef7fff64389b814a946f3e92105513705ca6b990",
-            "salt": "256",
             "feeRecipient": "0xB046140686d052ffF581f63f8136CcE132e857dA",
-            "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
+            "makerTokenAmount": "10000000000000000",
+            "takerTokenAmount": "20000000000000000",
+            "makerFee": "100000000000000",
+            "takerFee": "200000000000000",
             "expirationUnixTimestampSec": "42",
+            "salt": "67006738228878699843088602623665307406148487219438534730168799356281242528500",
             "ecSignature": {
                 "v": 27,
                 "r": "0x61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33",
                 "s": "0x40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"
             }
-        },
-        "state": "OPEN",
-        "pending": {
-            "fillAmount": "50000000000000000",
-            "cancelAmount": "50000000000000000"
-        },
-        "remainingTakerTokenAmount": "1000000000000000000"
-    }
+        }
+    },
     ...
 ]
 ```
 
-- `state` - the state of the order. The order is `OPEN` until completely filled/canceled.
 
-### GET /v0/order/[orderHash]
+### GET /v0/orders/[orderHash]
 
 Retrieves a specific order by orderHash.
 
 #### Response
 
-[See response schema](https://github.com/0xProject/json-schemas/blob/master/schemas/relayer_api_order_response_schema.ts#L7)
+[See response schema](https://github.com/0xProject/json-schemas/blob/master/schemas/relayer_api_orders_response_schema.ts#L7)
 
 
 ```
 {
     "signedOrder": {
+        "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
         "maker": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
         "taker": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
-        "makerFee": "100000000000000",
-        "takerFee": "200000000000000",
-        "makerTokenAmount": "10000000000000000",
-        "takerTokenAmount": "20000000000000000",
         "makerTokenAddress": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
         "takerTokenAddress": "0xef7fff64389b814a946f3e92105513705ca6b990",
-        "salt": "256",
         "feeRecipient": "0xB046140686d052ffF581f63f8136CcE132e857dA",
-        "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
+        "makerTokenAmount": "10000000000000000",
+        "takerTokenAmount": "20000000000000000",
+        "makerFee": "100000000000000",
+        "takerFee": "200000000000000",
         "expirationUnixTimestampSec": "42",
+        "salt": "67006738228878699843088602623665307406148487219438534730168799356281242528500",
         "ecSignature": {
             "v": 27,
             "r": "0x61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33",
             "s": "0x40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"
         }
-    },
-    "state": "OPEN",
-    "pending": {
-        "fillAmount": "50000000000000000",
-        "cancelAmount": "50000000000000000"
-    },
-    "remainingTakerTokenAmount": "10000000000000000"
+    }
 }
 ```
 
@@ -173,21 +160,23 @@ Returns HTTP 404 if no order with specified orderHash was found.
 
 ### POST /v0/fees
 
-Returns the only acceptable fees (in ZRX) for the specified order parameters
+Given an unsigned order without the fee-related properties, returns the required `feeRecipient`, `makerFee`, and `takerFee` of that order.
 
 #### Payload
 
 [See payload schema](https://github.com/0xProject/json-schemas/blob/master/schemas/relayer_api_fees_payload_schema.ts)
 
-
 ```
 {
+    "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
     "maker": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
-    "taker": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "taker": "0x0000000000000000000000000000000000000000",
     "makerTokenAddress": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
     "takerTokenAddress": "0xef7fff64389b814a946f3e92105513705ca6b990",
-    "makerTokenAmount": "10000000000000000000",
-    "takerTokenAmount": "30000000000000000000"
+    "makerTokenAmount": "10000000000000000",
+    "takerTokenAmount": "20000000000000000",
+    "expirationUnixTimestampSec": "42",
+    "salt": "67006738228878699843088602623665307406148487219438534730168799356281242528500"
 }
 ```
 
@@ -197,39 +186,40 @@ Returns the only acceptable fees (in ZRX) for the specified order parameters
 
 ```
 {
-    "feeRecipient": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
-    "takerToSpecify": "0xef7fff64389b814a946f3e92105513705ca6b990",
-    "makerFee": "10000000000000000",
-    "takerFee": "30000000000000000"
+    "feeRecipient": "0xB046140686d052ffF581f63f8136CcE132e857dA",
+    "makerFee": "100000000000000",
+    "takerFee": "200000000000000"
 }
 ```
 
 ### POST /v0/order
 
-Submit an order to the relayer.
+Submit a signed order to the relayer.
 
 #### Payload
 
-[See payload schema](https://github.com/0xProject/json-schemas/blob/master/schemas/order_schemas.ts#L28)
+[See payload schema](https://github.com/0xProject/json-schemas/blob/master/schemas/relayer_api_order_payload_schema.ts)
 
 ```
 {
-    "maker": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
-    "taker": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
-    "makerFee": "100000000000000",
-    "takerFee": "200000000000000",
-    "makerTokenAmount": "10000000000000000",
-    "takerTokenAmount": "20000000000000000",
-    "makerTokenAddress": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
-    "takerTokenAddress": "0xef7fff64389b814a946f3e92105513705ca6b990",
-    "salt": "256",
-    "feeRecipient": "0xB046140686d052ffF581f63f8136CcE132e857dA",
-    "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
-    "expirationUnixTimestampSec": "42",
-    "ecSignature": {
-        "v": 27,
-        "r": "0x61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33",
-        "s": "0x40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"
+    "signedOrder": {
+        "exchangeContractAddress": "0x12459C951127e0c374FF9105DdA097662A027093",
+        "maker": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+        "taker": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+        "makerTokenAddress": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
+        "takerTokenAddress": "0xef7fff64389b814a946f3e92105513705ca6b990",
+        "feeRecipient": "0xB046140686d052ffF581f63f8136CcE132e857dA",
+        "makerTokenAmount": "10000000000000000",
+        "takerTokenAmount": "20000000000000000",
+        "makerFee": "100000000000000",
+        "takerFee": "200000000000000",
+        "expirationUnixTimestampSec": "42",
+        "salt": "67006738228878699843088602623665307406148487219438534730168799356281242528500",
+        "ecSignature": {
+            "v": 27,
+            "r": "0x61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33",
+            "s": "0x40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"
+        }
     }
 }
 ```


### PR DESCRIPTION
This PR: 
- Removes all trusted information provided by the relayer for the sake of convenience (token symbols, decimals, order blockchain state). Malicious relayers could manipulate this information to guide trading behavior and potentially cause traders to lose money. 
- Modifies fees endpoint. The fees payload now expects an entire unsigned order minus fee information, and then returns the fee information for that order.