### PR TITLE
Adding timestamp to websocket response

### DIFF
--- a/ws/v2.md
+++ b/ws/v2.md
@@ -110,11 +110,12 @@ Updates can be sent in bulk since the payload of the message specifies a collect
               "makerAssetData": "0xf47261b04c32345ced77393b3530b1eed0f346429d",
               "takerAssetData": "0x0257179264389b814a946f3e92105513705ca6b990",
               "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
-              "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33",
-              "timestamp": 1537375071174
+              "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
             },
             "metaData": {
-              "remainingTakerAssetAmount": "500000000"
+              "remainingTakerAssetAmount": "500000000",
+              "timestamp": 1537375071174,
+              "mostRecentBlock" : 6402822
             }
         },
         ...
@@ -123,4 +124,5 @@ Updates can be sent in bulk since the payload of the message specifies a collect
 ```
 
 *   `requestId` - a string uuid that corresponds to the requestId sent by the client in the `subscribe` message
-*   `timestamp` - mandatory field depicting the last time this order was updated. If this is a new order it represents when the order was first signed. Its format is UTC (UNIX Epoch time in milliseconds).
+*   `timestamp` - a mandatory 64-bit integer depicting the last time this order was updated. If this is a new order it represents when the order was first signed. Its format is UTC (UNIX Epoch time in milliseconds).
+*   `mostRecentBlock` - a mandatory 64-bit integer to be used in conjunction with timestamp to give an approximation of when this order was last updated on the blockchain

--- a/ws/v2.md
+++ b/ws/v2.md
@@ -110,7 +110,8 @@ Updates can be sent in bulk since the payload of the message specifies a collect
               "makerAssetData": "0xf47261b04c32345ced77393b3530b1eed0f346429d",
               "takerAssetData": "0x0257179264389b814a946f3e92105513705ca6b990",
               "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
-              "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
+              "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33",
+              "timestamp": 1537375071174
             },
             "metaData": {
               "remainingTakerAssetAmount": "500000000"
@@ -122,3 +123,4 @@ Updates can be sent in bulk since the payload of the message specifies a collect
 ```
 
 *   `requestId` - a string uuid that corresponds to the requestId sent by the client in the `subscribe` message
+*   `timestamp` - mandatory field depicting the last time this order was updated. If this is a new order it represents when the order was first signed. Its format is UTC (UNIX Epoch time in milliseconds).

--- a/ws/v2.md
+++ b/ws/v2.md
@@ -124,5 +124,5 @@ Updates can be sent in bulk since the payload of the message specifies a collect
 ```
 
 *   `requestId` - a string uuid that corresponds to the requestId sent by the client in the `subscribe` message
-*   `timestamp` - a mandatory 64-bit integer depicting the last time this order was updated. If this is a new order it represents when the order was first signed. Its format is UTC (UNIX Epoch time in milliseconds).
-*   `mostRecentBlock` - a mandatory 64-bit integer to be used in conjunction with timestamp to give an approximation of when this order was last updated on the blockchain
+*   `timestamp` - a 64-bit integer depicting the last time this order was updated. If this is a new order it represents when the order was first signed. Its format is UTC (UNIX Epoch time in milliseconds).
+*   `mostRecentBlock` - a 64-bit integer to be used in conjunction with timestamp to give an approximation of when this order was last updated on the blockchain


### PR DESCRIPTION
Adding timestamp as a mandatory field to the payload in the v2 websocket specification. This allows us to determine which update of an order is the latest.