### PR TITLE
Remove Asset Data Encoding from SRA v2 TOC

### DIFF
--- a/http/v2.md
+++ b/http/v2.md
@@ -7,7 +7,6 @@
     *   [Network Id](#network-id)
     *   [Link Header](#link-header)
     *   [Rate Limits](#rate-limits)
-    *   [Asset Data Encoding](#asset-data-encoding)
     *   [Errors](#errors)
     *   [Misc](#misc)
 *   [REST API](#rest-api)


### PR DESCRIPTION
This section doesn't appear in the document itself.