### PR TITLE
Remove sra-report link since its removal for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ The URL that specifies the SRA API endpoint should end in the version. Here are 
 
 **Websocket**: `wss://api.relayer.com/sra/v0/`, `wss://api.relayer.com/sra/v2/`
 
-### Testing
-
-Use the [sra-report](https://github.com/0xProject/0x-monorepo/tree/development/packages/sra-report) command line tool to test your API for standard relayer API compliance.
-
 ### Schemas
 
 The [JSON schemas](http://json-schema.org/) for the API payloads and responses can be found in [@0xproject/json-schemas](https://github.com/0xProject/0x.js/tree/development/packages/json-schemas). Examples of each payload and response can be found in the library's [test suite](https://github.com/0xProject/0x.js/blob/development/packages/json-schemas/test/schema_test.ts#L1).


### PR DESCRIPTION
sra-report was removed after v2 was released and it wasn't updated. 