### PR TITLE
Define SRA v3 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,12 @@
 
 ## Specification Versions
 
-### SRA v0
+### SRA v3
 
-Made to match [0x Protocol v1](https://github.com/0xProject/0x-protocol-specification/blob/master/v1/v1-whitepaper.pdf)
+Made to match [0x Protocol v3](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md)
 
-- [HTTP](https://github.com/0xProject/standard-relayer-api/blob/master/http/v0.md)
-- [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v0.md)
-
-### SRA v1
-
-Skipped for naming convention and convenience reasons.
+- [HTTP](https://github.com/0xProject/standard-relayer-api/blob/master/http/v3.md)
+- [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v3.md)
 
 ### SRA v2
 
@@ -23,12 +19,16 @@ Made to match [0x Protocol v2](https://github.com/0xProject/0x-protocol-specific
 - [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v2.md)
 - OpenAPI Spec ([Docs](http://sra-spec.s3-website-us-east-1.amazonaws.com/), [Package](https://github.com/0xProject/0x-monorepo/tree/development/packages/sra-spec))
 
-### SRA v3
+### SRA v1
 
-Made to match [0x Protocol v3](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md)
+Skipped for naming convention and convenience reasons.
 
-- [HTTP](https://github.com/0xProject/standard-relayer-api/blob/master/http/v3.md)
-- [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v3.md)
+### SRA v0
+
+Made to match [0x Protocol v1](https://github.com/0xProject/0x-protocol-specification/blob/master/v1/v1-whitepaper.pdf)
+
+- [HTTP](https://github.com/0xProject/standard-relayer-api/blob/master/http/v0.md)
+- [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v0.md)
 
 ## General Info
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Made to match [0x Protocol v2](https://github.com/0xProject/0x-protocol-specific
 - [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v2.md)
 - OpenAPI Spec ([Docs](http://sra-spec.s3-website-us-east-1.amazonaws.com/), [Package](https://github.com/0xProject/0x-monorepo/tree/development/packages/sra-spec))
 
+### SRA v3
+
+Made to match [0x Protocol v3](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md)
+
+- [HTTP](https://github.com/0xProject/standard-relayer-api/blob/master/http/v3.md)
+- [WebSocket](https://github.com/0xProject/standard-relayer-api/blob/master/ws/v3.md)
+
 ## General Info
 
 ### Versioning

--- a/http/v3.md
+++ b/http/v3.md
@@ -263,7 +263,7 @@ While there is some redundancy in supporting maker/takerAssetType, maker/takerAs
           "order": {
               "domain": {
                   "chainId": 1,
-                  "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+                  "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
               },
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
@@ -301,7 +301,7 @@ Retrieves a specific order by orderHash.
       "order": {
           "domain": {
             "chainId": 1,
-            "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+            "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
           },
           "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
           "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
@@ -349,7 +349,7 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
                 "order": {
                     "domain": {
                         "chainId": 1,
-                        "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+                        "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
                     },
                     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
@@ -381,7 +381,7 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
                 "order":  {
                     "domain": {
                         "chainId": 1,
-                        "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+                        "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
                     },
                     "makerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "takerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
@@ -426,7 +426,7 @@ Relayers have full discretion over the orders that they are willing to host on t
 {
     "domain": {
         "chainId": 1,
-        "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+        "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
     },
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",

--- a/http/v3.md
+++ b/http/v3.md
@@ -1,0 +1,523 @@
+# HTTP REST API Specification v3
+
+## Table of Contents
+
+*   [General](#general)
+    *   [Pagination](#pagination)
+    *   [Network Id](#network-id)
+    *   [Link Header](#link-header)
+    *   [Rate Limits](#rate-limits)
+    *   [Errors](#errors)
+    *   [Misc](#misc)
+*   [REST API](#rest-api)
+    *   [GET asset_pairs](#get-v3asset_pairs)
+    *   [GET orders](#get-v3orders)
+    *   [GET order](#get-v3orderorderhash)
+    *   [GET orderbook](#get-v3orderbook)
+    *   [POST order_config](#post-v3order_config)
+    *   [GET fee_recipients](#get-v3fee_recipients)
+    *   [POST order](#post-v3order)
+
+## General
+
+### Pagination
+
+Requests that return potentially large collections should respond to the **?page** and **?perPage** parameters. For example:
+
+```
+curl https://api.example-relayer.com/v3/token_pairs?page=3&perPage=20
+```
+
+Page numbering should be 1-indexed, not 0-indexed. If a query provides an unreasonable (ie. too high) **perPage** value, the response can return a validation error as specified in the [errors section](#errors). If the query specifies a **page** that does not exist (ie. there are not enough **records**), the response should just return an empty **records** array.
+
+All endpoints that are paginated should return a **total**, **page**, **perPage** and a **records** value in the top level of the collection.  The value of **total** should be the total number of records for a given query, whereas **records** should be an array representing the response to the query for that page. **page** and **perPage**, are the same values that were specified in the request. 
+
+These requests include the [`asset_pairs`](#get-v3-asset-pairs), [`orders`](#get-v3-orders), and [`orderbook`](#get-v3-orderbook) endpoints.
+
+### Network Id
+All requests should be able to specify a **?networkId** query param for all supported networks. For example:
+```
+curl https://api.example-relayer.com/v3/token_pairs?networkId=1
+```
+If the query param is not provided, it should default to **1** (mainnet).
+
+Networks and their Ids:
+
+| Network Id| Network Name |
+| ----------| ------------ |
+| 1         | Mainnet      |
+| 42        | Kovan        |
+| 3         | Ropsten      |
+| 4         | Rinkeby      |
+
+ If a certain network is not supported, the response should **400**  as specified in the [error response](#error-response) section. For example:
+ 
+```
+{
+    "code": 100,
+    "reason": "Validation failed",
+    "validationErrors": [
+        {
+            "field": "networkId",
+            "code": 1006,
+            "reason": "Network id 42 is not supported",
+        }
+    ]
+}
+```
+
+### Link Header
+
+A [Link Header](https://tools.ietf.org/html/rfc5988) can be included in a response to provide clients with more context about paging
+For example:
+
+```
+Link: <https://api.example-relayer.com/v3/token_pairs?page=3&perPage=20>; rel="next",
+<https://api.github.com/user/repos?page=10&perPage=20>; rel="last"
+```
+
+This `Link` response header contains one or more Hypermedia link relations.
+
+The possible `rel` values are:
+
+| Name  | Description                                                   |
+| ----- | ------------------------------------------------------------- |
+| next  | The link relation for the immediate next page of results.     |
+| last  | The link relation for the last page of results.               |
+| first | The link relation for the first page of results.              |
+| prev  | The link relation for the immediate previous page of results. |
+
+### Rate Limits
+
+Rate limit guidance for clients can be optionally returned in the response headers:
+
+| Header Name           | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| X-RateLimit-Limit     | The maximum number of requests you're permitted to make per hour.            |
+| X-RateLimit-Remaining | The number of requests remaining in the current rate limit window.           |
+| X-RateLimit-Reset     | The time at which the current rate limit window resets in UTC epoch seconds. |
+
+For example:
+
+```
+curl -i https://api.example-relayer.com/v3/token_pairs
+HTTP/1.1 200 OK
+Date: Mon, 20 Oct 2017 12:30:06 GMT
+Status: 200 OK
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 56
+X-RateLimit-Reset: 1372700873
+```
+When a rate limit is exceeded, a status of **429 Too Many Requests** should be returned.
+
+### Errors
+
+Unless the spec defines otherwise, errors to bad requests should respond with HTTP 4xx or status codes.
+
+#### Common error codes
+
+| Code | Reason                                  |
+| ---- | --------------------------------------- |
+| 400  | Bad Request – Invalid request format    |
+| 404  | Not found                               |
+| 429  | Too many requests - Rate limit exceeded |
+| 500  | Internal Server Error                   |
+| 501  | Not Implemented                         |
+
+#### Error reporting format
+For all **400** responses, see the [error response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_error_response_schema.json#L1).
+
+```
+{
+    "code": 101,
+    "reason": "Validation failed",
+    "validationErrors": [
+        {
+            "field": "maker",
+            "code": 1002,
+            "reason": "Invalid address"
+        }
+    ]
+}
+```
+
+General error codes:
+
+```
+100 - Validation Failed
+101 - Malformed JSON
+102 - Order submission disabled
+103 - Throttled
+```
+
+Validation error codes:
+
+```
+1000 - Required field
+1001 - Incorrect format
+1002 - Invalid address
+1003 - Address not supported
+1004 - Value out of range
+1005 - Invalid signature or hash
+1006 - Unsupported option
+```
+
+### Domain field
+
+The new `domain` field contains the [EIP-712 domain](https://github.com/0xProject/0x-protocol-specification/blob/development/v3/v3-specification.md#eip-712-usage) information which is used to identify orders on different networks and compute the [`orderHash`](https://github.com/0xProject/0x-protocol-specification/blob/development/v3/v3-specification.md#hashing-an-order).
+
+
+### Misc.
+
+*   All requests and responses should be of **application/json** content type
+*   All token amounts are sent in amounts of the smallest level of precision (base units). (e.g if a token has 18 decimal places, selling 1 token would show up as selling `'1000000000000000000'` units by this API).
+*   All addresses are sent as lower-case (non-checksummed) Ethereum addresses with the `0x` prefix.
+*   All parameters should use `lowerCamelCase`.
+
+## REST API
+
+### GET /v3/asset_pairs
+
+Retrieves a list of available asset pairs and the information required to trade them. This endpoint should be [paginated](#pagination).
+
+#### Parameters
+
+*   assetDataA=&assetDataB [string]: these are assetData fields. Returns asset pairs that contain assetDataA and assetDataB (in any order). Setting only assetDataA or assetDataB returns pairs filtered by that asset only (optional)
+
+#### Response
+
+[See response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_asset_data_pairs_response_schema.json#L1)
+
+```
+{
+    "total": 43,
+    "page": 1,
+    "perPage": 100,
+    "records": [
+        {
+            "assetDataA": {
+                "minAmount": "0",
+                "maxAmount": "10000000000000000000",
+                "precision": 5,
+                "assetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498"
+            },
+            "assetDataB": {
+                "minAmount": "0",
+                "maxAmount": "50000000000000000000",
+                "precision": 5,
+                "assetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063"
+            }
+        },
+        ...
+    ]
+}
+```
+
+*   `minAmount` - the minimum trade amount the relayer will accept
+*   `maxAmount` - the maximum trade amount the relayer will accept
+*   `precision` - the desired price precision a relayer would like to support within their orderbook
+*   `assetData` - the assetData representing that token
+
+### GET /v3/orders
+
+Retrieves a list of orders given query parameters. This endpoint should be [paginated](#pagination). For querying an entire orderbook snapshot, the [orderbook endpoint](#get-v3orderbook) is recommended.
+
+#### Parameters
+
+Filter parameters:
+  *   makerAssetProxyId [string]: returns orders where the maker asset is of certain [asset proxy id](https://0xproject.com/docs/0x.js#types-AssetProxyId) (example: `0xf47261b0` for `ERC20`, `0x02571792` for `ERC721`)
+  *   takerAssetProxyId [string]:  returns orders where the taker asset is of certain [asset proxy id](https://0xproject.com/docs/0x.js#types-AssetProxyId)(example: `0xf47261b0` for `ERC20`, `0x02571792` for `ERC721`)
+  *   makerAssetAddress [string] returns orders where the contract address for the maker asset matches the value specified
+  *   takerAssetAddress [string] returns orders where the contract address for the taker asset matches the value specified
+
+Order specific parameters:
+  *   senderAddress [string]: returns orders with the specified senderAddress
+  *   makerAssetData [string]: returns orders with the specified makerAssetData
+  *   takerAssetData [string]: returns orders with the specified takerAssetData
+  *   traderAssetData [string]: returns orders where either makerAssetData or takerAssetData has the value specified
+  *   makerAddress [string]: returns orders with the specified makerAddress
+  *   takerAddress [string]: returns orders with the specified takerAddress
+  *   traderAddress [string]: returns orders where either makerAddress or takerAddress has the value specified
+  *   feeRecipientAddress [string]: returns orders where feeRecipientAddress is feeRecipient address
+  *   makerFeeAssetData [string]: returns orders with the specified makerFeeAssetData
+  *   takerFeeAssetData [string]: returns orders with the specified takerFeeAssetData
+
+All parameters are optional.
+
+If both makerAssetData and takerAssetData are specified, returned orders will be sorted by price determined by (takerAssetAmount/makerAssetAmount) in ascending order. By default, orders returned by this endpoint are unsorted.
+
+While there is some redundancy in supporting maker/takerAssetType, maker/takerAssetAddress, and maker/takerAssetData, they are actually all needed. For example, you cannot query "all ERC712 orders", or "all Cryptokitties orders", or "all ERC20 orders" with just maker/takerAssetData and need the other query params to do so.
+
+#### Response
+
+[See response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_orders_response_schema.json#L1)
+
+
+```
+{
+    "total": 984,
+    "page": 1,
+    "perPage": 100,
+    "records": [
+        {
+          "order": {
+              "domain": {
+                  "chainId": 1,
+                  "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+              },
+              "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+              "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+              "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+              "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+              "makerAssetAmount": "10000000000000000",
+              "takerAssetAmount": "20000000000000000",
+              "makerFee": "100000000000000",
+              "takerFee": "200000000000000",
+              "expirationTimeSeconds": "1532560590",
+              "salt": "1532559225",
+              "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+              "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+              "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+              "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+              "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
+            },
+            "metaData": {}
+        }
+        ...
+    ]
+}
+```
+
+### GET /v3/order/[orderHash]
+
+Retrieves a specific order by orderHash.
+
+#### Response
+
+[See response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/signed_order_schema.json#L1)
+
+```
+{
+      "order": {
+          "domain": {
+            "chainId": 1,
+            "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+          },
+          "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+          "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+          "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+          "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+          "makerAssetAmount": "10000000000000000",
+          "takerAssetAmount": "20000000000000000",
+          "makerFee": "100000000000000",
+          "takerFee": "200000000000000",
+          "expirationTimeSeconds": "1532560590",
+          "salt": "1532559225",
+          "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+          "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+          "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+          "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+          "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
+      },
+      "metaData": {}
+}
+```
+
+Returns HTTP 404 if no order with specified orderHash was found.
+
+### GET /v3/orderbook
+
+Retrieves the orderbook for a given asset pair. This endpoint should be [paginated](#pagination).
+
+#### Parameters
+
+*   baseAssetData [string]: assetData (makerAssetData or takerAssetData) designated as the base currency in the [currency pair calculation](https://en.wikipedia.org/wiki/Currency_pair) of price (required)
+*   quoteAssetData [string]: assetData (makerAssetData or takerAssetData) designated as the quote currency in the currency pair calculation of price (required)
+
+#### Response
+
+[See response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_orderbook_response_schema.json#L1)
+
+```
+{
+    "bids": {
+        "total": 325,
+        "page": 2,
+        "perPage": 100,
+        "records": [
+            {
+                "order": {
+                    "domain": {
+                        "chainId": 1,
+                        "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+                    },
+                    "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+                    "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+                    "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+                    "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+                    "makerAssetAmount": "10000000000000000",
+                    "takerAssetAmount": "20000000000000000",
+                    "makerFee": "100000000000000",
+                    "takerFee": "200000000000000",
+                    "expirationTimeSeconds": "1532560590",
+                    "salt": "1532559225",
+                    "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+                    "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+                    "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+                    "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+                    "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
+                }
+                "metaData": {}
+          },
+          ...
+        ]
+    }
+    "asks": {
+        "total": 500,
+        "page": 2,
+        "perPage": 100,
+        "records": [
+            {
+                "order":  {
+                    "domain": {
+                        "chainId": 1,
+                        "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+                    },
+                    "makerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+                    "takerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+                    "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+                    "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+                    "makerAssetAmount": "20000000000000000",
+                    "takerAssetAmount": "10000000000000000",
+                    "makerFee": "200000000000000",
+                    "takerFee": "100000000000000",
+                    "expirationTimeSeconds": "1532560590",
+                    "salt": "1532559225",
+                    "makerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+                    "takerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+                    "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+                    "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+                    "signature": "0x013842a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b3518891"
+                },
+                "metaData": {}
+            },
+          ...
+        ]  
+    }
+}
+```
+
+*   `bids` - array of signed orders where `takerAssetData` is equal to `baseAssetData`
+*   `asks` - array of signed orders where `makerAssetData` is equal to `baseAssetData`
+
+Bids will be sorted in descending order by price, and asks will be sorted in ascending order by price. Within the price sorted orders, the orders are further sorted by _taker fee price_ which is defined as the **takerFee** divided by **takerTokenAmount**. After _taker fee price_, orders are to be sorted by expiration in ascending order.
+
+The way pagination works for this endpoint is that the **page** and **perPage** query params apply to both `bids` and `asks` collections, and if `page` * `perPage` > `total` for a certain collection, the `records` for that collection should just be empty. 
+
+### POST /v3/order_config
+
+Relayers have full discretion over the orders that they are willing to host on their orderbooks (e.g what fees they charge, etc...). In order for traders to discover their requirements programmatically, they can send an incomplete order to this endpoint and receive the missing fields, specifc to that order. This gives relayers a large amount of flexibility to tailor fees to unique traders, trading pairs and volume amounts. Submit a partial order and receive information required to complete the order: `senderAddress`, `feeRecipientAddress`, `makerFee`, `takerFee`. 
+
+#### Payload
+
+[See payload schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_order_config_payload_schema.json#L1)
+
+```
+{
+    "domain": {
+        "chainId": 1,
+        "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+    },
+    "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+    "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "makerAssetAmount": "10000000000000000",
+    "takerAssetAmount": "20000000000000000",
+    "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+    "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+    "expirationTimeSeconds": "1532560590"
+}
+```
+
+#### Response
+
+[See response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_order_config_response_schema.json#L1)
+
+###### Success Response
+
+Returns a HTTP 201 response with the following payload:
+```
+{
+    "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+    "makerFee": "100000000000000",
+    "takerFee": "200000000000000"
+}
+```
+
+###### Error Response
+
+Error response will be sent with a non-2xx HTTP status code. See the [Errors](#errors) section for more information.
+
+### GET /v3/fee_recipients
+
+Retrieves a list of all fee recipient addresses for a relayer. This endpoint should be [paginated](#pagination).
+
+#### Parameters
+
+No custom parameters, just pagination parameters.
+
+#### Response
+
+[See response schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_fee_recipients_response_schema.json#L1)
+
+```
+{
+    "total": 3,
+    "page": 1,
+    "perPage": 10,
+    "records": [
+        "0x6eC92694ea172ebC430C30fa31De87620967A082", 
+        "0x9e56625509c2f60af937f23b7b532600390e8c8b", 
+        "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32"
+    ]
+}
+```
+
+
+### POST /v3/order
+
+Submit a signed order to the relayer.
+
+#### Payload
+
+[See payload schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/signed_order_schema.json#L1)
+
+```
+{
+    "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+    "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+    "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "makerAssetAmount": "10000000000000000",
+    "takerAssetAmount": "20000000000000000",
+    "makerFee": "100000000000000",
+    "takerFee": "200000000000000",
+    "expirationTimeSeconds": "1532560590",
+    "salt": "1532559225",
+    "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+    "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+    "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+    "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+    "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
+}
+```
+
+#### Response
+
+###### Success Response
+
+Returns HTTP 201 upon success.
+
+###### Error Response
+
+Error response will be sent with a non-2xx HTTP status code. See the [Errors](#errors) section for more information.

--- a/http/v3.md
+++ b/http/v3.md
@@ -261,10 +261,7 @@ While there is some redundancy in supporting maker/takerAssetType, maker/takerAs
     "records": [
         {
           "order": {
-              "domain": {
-                  "chainId": 1,
-                  "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
-              },
+              "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
               "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -299,10 +296,7 @@ Retrieves a specific order by orderHash.
 ```
 {
       "order": {
-          "domain": {
-            "chainId": 1,
-            "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
-          },
+          "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
           "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
           "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
           "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -347,7 +341,7 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
         "records": [
             {
                 "order": {
-                    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
+                    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
                     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -376,7 +370,7 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
         "records": [
             {
                 "order":  {
-                    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
+                    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
                     "makerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "takerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -418,7 +412,7 @@ Relayers have full discretion over the orders that they are willing to host on t
 
 ```
 {
-    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
+    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "makerAssetAmount": "10000000000000000",
@@ -487,7 +481,7 @@ Submit a signed order to the relayer.
 
 ```
 {
-    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
+    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",

--- a/http/v3.md
+++ b/http/v3.md
@@ -164,7 +164,7 @@ Validation error codes:
 
 ### Domain field
 
-The new `domain` field contains the [EIP-712 domain](https://github.com/0xProject/0x-protocol-specification/blob/development/v3/v3-specification.md#eip-712-usage) information which is used to identify orders on different networks and compute the [`orderHash`](https://github.com/0xProject/0x-protocol-specification/blob/development/v3/v3-specification.md#hashing-an-order).
+The new `domain` field contains the [EIP-712 domain](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#eip-712-usage) information which is used to identify orders on different networks and compute the [`orderHash`](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#hashing-an-order).
 
 
 ### Misc.

--- a/http/v3.md
+++ b/http/v3.md
@@ -162,11 +162,6 @@ Validation error codes:
 1006 - Unsupported option
 ```
 
-### Domain hash field
-
-The new `domainHash` field contains the hash of the [EIP-712 domain](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#eip-712-usage) information which is used to identify orders on different networks and compute the [`orderHash`](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#hashing-an-order).
-
-
 ### Misc.
 
 *   All requests and responses should be of **application/json** content type
@@ -261,7 +256,8 @@ While there is some redundancy in supporting maker/takerAssetType, maker/takerAs
     "records": [
         {
           "order": {
-              "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
+              "chainId": 1,
+              "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
               "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -296,7 +292,8 @@ Retrieves a specific order by orderHash.
 ```
 {
       "order": {
-          "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
+          "chainId": 1,
+          "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
           "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
           "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
           "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -341,7 +338,8 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
         "records": [
             {
                 "order": {
-                    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
+                    "chainId": 1,
+                    "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
                     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -370,7 +368,8 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
         "records": [
             {
                 "order":  {
-                    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
+                    "chainId": 1,
+                    "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
                     "makerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "takerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -412,7 +411,8 @@ Relayers have full discretion over the orders that they are willing to host on t
 
 ```
 {
-    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
+    "chainId": 1,
+    "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "makerAssetAmount": "10000000000000000",
@@ -481,7 +481,8 @@ Submit a signed order to the relayer.
 
 ```
 {
-    "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
+    "chainId": 1,
+    "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",

--- a/http/v3.md
+++ b/http/v3.md
@@ -450,7 +450,9 @@ Returns a HTTP 201 response with the following payload:
     "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
     "makerFee": "100000000000000",
-    "takerFee": "200000000000000"
+    "takerFee": "200000000000000",
+    "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+    "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498"
 }
 ```
 

--- a/http/v3.md
+++ b/http/v3.md
@@ -162,9 +162,9 @@ Validation error codes:
 1006 - Unsupported option
 ```
 
-### Domain field
+### Domain hash field
 
-The new `domain` field contains the [EIP-712 domain](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#eip-712-usage) information which is used to identify orders on different networks and compute the [`orderHash`](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#hashing-an-order).
+The new `domainHash` field contains the hash of the [EIP-712 domain](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#eip-712-usage) information which is used to identify orders on different networks and compute the [`orderHash`](https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#hashing-an-order).
 
 
 ### Misc.
@@ -347,10 +347,7 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
         "records": [
             {
                 "order": {
-                    "domain": {
-                        "chainId": 1,
-                        "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
-                    },
+                    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
                     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -379,10 +376,7 @@ Retrieves the orderbook for a given asset pair. This endpoint should be [paginat
         "records": [
             {
                 "order":  {
-                    "domain": {
-                        "chainId": 1,
-                        "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
-                    },
+                    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
                     "makerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
                     "takerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
                     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
@@ -424,10 +418,7 @@ Relayers have full discretion over the orders that they are willing to host on t
 
 ```
 {
-    "domain": {
-        "chainId": 1,
-        "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
-    },
+    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "makerAssetAmount": "10000000000000000",
@@ -496,6 +487,7 @@ Submit a signed order to the relayer.
 
 ```
 {
+    "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
     "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
     "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
     "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -99,7 +99,7 @@ Updates can be sent in bulk since the payload of the message specifies a collect
     "payload":  [
         {
           "order": {
-              "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
+              "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
               "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -99,6 +99,7 @@ Updates can be sent in bulk since the payload of the message specifies a collect
     "payload":  [
         {
           "order": {
+              "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
               "domainHash" "0x78772b297e1b0b31089589a6608930cceba855af9d3ccf7b92cf47fa881e21f7",
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -101,7 +101,7 @@ Updates can be sent in bulk since the payload of the message specifies a collect
           "order": {
               "domain": {
                 "chainId": 1,
-                "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+                "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
               },
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -1,0 +1,132 @@
+# WebSocket API Specification v3
+
+## Table of Contents
+
+- [WebSocket API Specification v3](#websocket-api-specification-v3)
+    - [Table of Contents](#table-of-contents)
+    - [Websocket API](#websocket-api)
+        - [Orders Channel](#orders-channel)
+            - [Request messages](#request-messages)
+                - [Subscribe](#subscribe)
+            - [Response messages](#response-messages)
+                - [Update](#update)
+
+## Websocket API
+
+The SRA Websocket API is meant to supplement the [REST API](https://github.com/0xProject/standard-relayer-api/blob/master/http/v3.md) by providing updates without resorting to polling.
+
+### Orders Channel
+
+#### Request messages
+
+##### Subscribe
+
+[See payload schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_orders_channel_subscribe_schema.json#L1)
+
+Minimum request:
+```
+{
+    "type": "subscribe",
+    "channel": "orders",
+    "requestId": "123e4567-e89b-12d3-a456-426655440000"
+}
+```
+This will subscribe to all new orders and order state changes in the orderbook.
+
+Filtered request:
+```
+{
+    "type": "subscribe",
+    "channel": "orders",
+    "requestId": "123e4567-e89b-12d3-a456-426655440000",
+    "payload": {
+        "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+        "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+        "networkId": 42,
+    }
+}
+```
+This will subscribe to all new Kovan orders and Kovan order state changes in the orderbook with `makerAssetData` and `takerAssetData` equal to the values specified in the subscribe request.
+
+**Parameters**
+
+General:
+*   `requestId`: a string uuid that will be sent back by the server in response messages so the client can appropriately respond when multiple subscriptions are made
+*   `networkId`: the Ethereum network id to which you'd like to subscribe. Default is 1 (mainnet). (optional)
+   
+Networks and their Ids:
+
+| Network Id| Network Name |
+| ----------| ------------ |
+| 1         | Mainnet      |
+| 42        | Kovan        |
+| 3         | Ropsten      |
+| 4         | Rinkeby      |
+
+Filter parameters (optional): 
+*   `makerAssetProxyId` : returns orders where the maker asset is of certain [asset proxy id](https://0xproject.com/docs/0x.js#types-AssetProxyId) (example: `0xf47261b0` for `ERC20`, `0x02571792` for `ERC721`)
+*   `takerAssetProxyId`:  returns orders where the taker asset is of certain [asset proxy id](https://0xproject.com/docs/0x.js#types-AssetProxyId)(example: `0xf47261b0` for `ERC20`, `0x02571792` for `ERC721`)
+*   `makerAssetAddress`: subscribes to new orders where the contract address for the maker asset matches the value specified
+*   `takerAssetAddress`: subscribes to new orders where the contract address for the taker asset matches the value specified
+
+Order specific parameters (optional):
+*   `makerAssetData`: subscribes to new orders with the specified makerAssetData
+*   `takerAssetData`: subscribes to new orders with the specified takerAssetData
+*   `traderAssetData`: subscribes to new orders where either makerAssetData or takerAssetData has the value specified
+
+While there is some redundancy in supporting maker/takerAssetType, maker/takerAssetAddress, and maker/takerAssetData, they are actually all needed. For example, you cannot query "all ERC712 orders", or "all Cryptokitties orders", or "all ERC20 orders" with just maker/takerAssetData and need the other query params to do so.
+
+#### Response messages
+
+##### Update
+
+This message is sent whenever the relayer receives a new order, or when the relayer deems an update necessary (such as when the state of the order changes). For example, some relayers may implement the `remainingTakerAssetAmount` field. If this is the case, the scenarios where an update may occur include:
+* The relayer received a new order.
+* An order was fully or partially filled, so `remainingTakerAssetAmount` has changed.
+* The order is cancelled.
+
+An update is not necessary for order expiration, as that information can be derived from the `expirationTimeSeconds` field in the order.
+
+Updates can be sent in bulk since the payload of the message specifies a collection of updated or new orders. 
+
+[See payload schema](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_orders_channel_update_response_schema.json#L1)
+
+```
+{
+    "type": "update",
+    "channel": "orders",
+    "requestId": "123e4567-e89b-12d3-a456-426655440000",
+    "payload":  [
+        {
+          "order": {
+              "domain": {
+                "chainId": 1,
+                "verifyingContractAddress": "0x080bf510fcbf18b91105470639e9561022937712"
+              },
+              "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+              "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+              "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+              "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+              "makerAssetAmount": "10000000000000000",
+              "takerAssetAmount": "20000000000000000",
+              "makerFee": "100000000000000",
+              "takerFee": "200000000000000",
+              "expirationTimeSeconds": "1532560590",
+              "salt": "1532559225",
+              "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+              "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
+              "exchangeAddress": "0x12459c951127e0c374ff9105dda097662a027093",
+              "makerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+              "takerFeeAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+              "signature": "0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"
+            },
+            "metaData": {
+              "remainingTakerAssetAmount": "500000000"
+            }
+        },
+        ...
+    ]
+}
+```
+
+*   `requestId` - a string uuid that corresponds to the requestId sent by the client in the `subscribe` message

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -99,10 +99,7 @@ Updates can be sent in bulk since the payload of the message specifies a collect
     "payload":  [
         {
           "order": {
-              "domain": {
-                "chainId": 1,
-                "verifyingContract": "0x080bf510fcbf18b91105470639e9561022937712"
-              },
+              "domainHash" "0xb1b295f2c1ed6b459ddeb95701466e4e0b385527a6cfa3873ae72a63c08466b6",
               "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
               "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
               "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",


### PR DESCRIPTION
- Changes order schema in examples:

  - Adds `chainId`, representing the unique identifier of the chain (almost equivalent to networkId) [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md)
  - Adds `makerFeeAssetData` and `takerFeeAssetData`.
- Adds `makerFeeAssetData` and `takerFeeAssetData` as query-able fields in the `/order` endpoint.
* Add `makerFeeAssetData` and `takerFeeAssetData` to `/order_config` endpoint.
* No endpoints have been added or removed.

The changes will be documented here: 
https://github.com/0xProject/standard-relayer-api/releases/tag/v3.0.0

The V3 HTTP docs also adds a section that briefly explains what a domain hash is.

### Questions:
Are we 100% sure that we want to use the `domain` object instead of the `domainHash`? 
The [new `SignedOrder`](https://github.com/0xProject/0x-monorepo/blob/3.0/packages/types/src/index.ts#L10) object uses the `domain` object, so this is more about whether we want to update that type as well.

**Answer: we moved to using `exchangeAddress` and `chainId`**

Do we want to add the "filter" queries for the fee asset datas as well? Right now the `order?` endpoint allows you to specify the `makerAssetProxyId`, `takerAssetProxyId` etc... This seems overkill for the fee assetDatas.

**Answer: nope**
