### PR TITLE
Remove networkId from SRA

### DIFF
--- a/http/v3.md
+++ b/http/v3.md
@@ -4,7 +4,6 @@
 
 *   [General](#general)
     *   [Pagination](#pagination)
-    *   [Network Id](#network-id)
     *   [Link Header](#link-header)
     *   [Rate Limits](#rate-limits)
     *   [Errors](#errors)
@@ -33,38 +32,6 @@ Page numbering should be 1-indexed, not 0-indexed. If a query provides an unreas
 All endpoints that are paginated should return a **total**, **page**, **perPage** and a **records** value in the top level of the collection.  The value of **total** should be the total number of records for a given query, whereas **records** should be an array representing the response to the query for that page. **page** and **perPage**, are the same values that were specified in the request. 
 
 These requests include the [`asset_pairs`](#get-v3-asset-pairs), [`orders`](#get-v3-orders), and [`orderbook`](#get-v3-orderbook) endpoints.
-
-### Network Id
-All requests should be able to specify a **?networkId** query param for all supported networks. For example:
-```
-curl https://api.example-relayer.com/v3/token_pairs?networkId=1
-```
-If the query param is not provided, it should default to **1** (mainnet).
-
-Networks and their Ids:
-
-| Network Id| Network Name |
-| ----------| ------------ |
-| 1         | Mainnet      |
-| 42        | Kovan        |
-| 3         | Ropsten      |
-| 4         | Rinkeby      |
-
- If a certain network is not supported, the response should **400**  as specified in the [error response](#error-response) section. For example:
- 
-```
-{
-    "code": 100,
-    "reason": "Validation failed",
-    "validationErrors": [
-        {
-            "field": "networkId",
-            "code": 1006,
-            "reason": "Network id 42 is not supported",
-        }
-    ]
-}
-```
 
 ### Link Header
 

--- a/http/v3.md
+++ b/http/v3.md
@@ -4,6 +4,7 @@
 
 *   [General](#general)
     *   [Pagination](#pagination)
+    *   [Chain Id](#chain-id)
     *   [Link Header](#link-header)
     *   [Rate Limits](#rate-limits)
     *   [Errors](#errors)
@@ -32,6 +33,9 @@ Page numbering should be 1-indexed, not 0-indexed. If a query provides an unreas
 All endpoints that are paginated should return a **total**, **page**, **perPage** and a **records** value in the top level of the collection.  The value of **total** should be the total number of records for a given query, whereas **records** should be an array representing the response to the query for that page. **page** and **perPage**, are the same values that were specified in the request. 
 
 These requests include the [`asset_pairs`](#get-v3-asset-pairs), [`orders`](#get-v3-orders), and [`orderbook`](#get-v3-orderbook) endpoints.
+
+### Chain Id
+The Standard Relayer API V3 does not specify how to deal with different chain ids (formerly called network ids). The recommendation is to provide a different SRA URL for every chain id that you support. For example, if your mainnet SRA endpoint is hosted at `https://api.relayer.com/sra/v3/` then the Kovan endpoint could be hosted at `https://kovan.api.relayer.com/sra/v3/`.
 
 ### Link Header
 

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -41,8 +41,7 @@ Filtered request:
     "requestId": "123e4567-e89b-12d3-a456-426655440000",
     "payload": {
         "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
-        "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063",
-        "networkId": 42,
+        "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063"
     }
 }
 ```
@@ -52,16 +51,6 @@ This will subscribe to all new Kovan orders and Kovan order state changes in the
 
 General:
 *   `requestId`: a string uuid that will be sent back by the server in response messages so the client can appropriately respond when multiple subscriptions are made
-*   `networkId`: the Ethereum network id to which you'd like to subscribe. Default is 1 (mainnet). (optional)
-   
-Networks and their Ids:
-
-| Network Id| Network Name |
-| ----------| ------------ |
-| 1         | Mainnet      |
-| 42        | Kovan        |
-| 3         | Ropsten      |
-| 4         | Rinkeby      |
 
 Filter parameters (optional): 
 *   `makerAssetProxyId` : returns orders where the maker asset is of certain [asset proxy id](https://0xproject.com/docs/0x.js#types-AssetProxyId) (example: `0xf47261b0` for `ERC20`, `0x02571792` for `ERC721`)

--- a/ws/v3.md
+++ b/ws/v3.md
@@ -3,13 +3,17 @@
 ## Table of Contents
 
 - [WebSocket API Specification v3](#websocket-api-specification-v3)
-    - [Table of Contents](#table-of-contents)
+
     - [Websocket API](#websocket-api)
         - [Orders Channel](#orders-channel)
             - [Request messages](#request-messages)
                 - [Subscribe](#subscribe)
             - [Response messages](#response-messages)
                 - [Update](#update)
+
+## Chain Id
+
+The Standard Relayer API V3 does not specify how to deal with different chain ids (formerly called network ids). The recommendation is to provide a different SRA URL for every chain id that you support. For example, if your mainnet SRA websocket endpoint is hosted at `ws://api.relayer.com/sra/v3/` then the Kovan endpoint could be hosted at `ws://kovan.api.relayer.com/sra/v3/`.
 
 ## Websocket API
 


### PR DESCRIPTION
From slack:
Would we be open to removing this parameter altogether? In practice, you have to deploy the APIs separately, and then route based on a query param which is a bit janky. Looking at Radars SRA, it seems like they don’t even support it (orders are from mainnet exchange) https://api.radarrelay.com/0x/v2/orders?networkId=42.

Release:
https://github.com/0xProject/standard-relayer-api/releases/tag/v3.0.0